### PR TITLE
Add tokyonight theme and language selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,34 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +47,27 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "brotli"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "cassowary"
@@ -83,7 +132,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -157,16 +218,22 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "papaya"
 version = "0.1.0"
 dependencies = [
  "crossterm",
- "rand",
+ "random_word",
  "ratatui",
 ]
 
@@ -227,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +326,21 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "random_word"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd87d2e3f99cc11e6c7fc518f09e63e194f7243b4cf30c979b0c524d04fbd90"
+dependencies = [
+ "ahash",
+ "brotli",
+ "once_cell",
+ "paste",
+ "rand",
+ "unicase",
 ]
 
 [[package]]
@@ -387,6 +474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,10 +498,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "winapi"
@@ -561,6 +669,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 ratatui = "0.25"
 crossterm = "0.27"
-rand = "0.8"
+random_word = { version = "0.5", features = ["en", "es", "de"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@ use crossterm::event::KeyEvent;
 
 use crate::stats::Stats;
 use crate::wordlist;
+use random_word::Lang;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppMode {
@@ -19,6 +20,8 @@ pub struct App {
     pub duration: Duration,
     pub durations: Vec<u64>,
     pub selected: usize,
+    pub languages: Vec<Lang>,
+    pub lang_selected: usize,
     pub should_quit: bool,
     pub stats: Stats,
     pub test_finished: bool,
@@ -34,6 +37,8 @@ impl App {
             duration: Duration::from_secs(60),
             durations: vec![30, 60, 120],
             selected: 1,
+            languages: vec![Lang::En, Lang::Es, Lang::De],
+            lang_selected: 0,
             should_quit: false,
             stats: Stats::default(),
             test_finished: false,
@@ -59,6 +64,16 @@ impl App {
             KeyCode::Down | KeyCode::Char('j') => {
                 if self.selected + 1 < self.durations.len() {
                     self.selected += 1;
+                }
+            }
+            KeyCode::Left | KeyCode::Char('h') => {
+                if self.lang_selected > 0 {
+                    self.lang_selected -= 1;
+                }
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                if self.lang_selected + 1 < self.languages.len() {
+                    self.lang_selected += 1;
                 }
             }
             KeyCode::Enter => {
@@ -105,7 +120,8 @@ impl App {
     }
 
     fn start_test(&mut self) {
-        let words = wordlist::random_words(50);
+        let lang = self.languages[self.lang_selected];
+        let words = wordlist::random_words(50, lang);
         self.target = words.join(" ");
         self.typed.clear();
         self.started = None;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -17,16 +17,16 @@ pub struct Theme {
 impl Default for Theme {
     fn default() -> Self {
         Self {
-            background: Color::Rgb(30, 30, 46),      // Catppuccin base
-            text: Color::Rgb(205, 214, 244),         // Catppuccin text
-            accent: Color::Rgb(137, 180, 250),       // Blue
-            correct: Color::Rgb(166, 227, 161),
-            incorrect: Color::Rgb(243, 139, 168),
-            pending: Color::Rgb(108, 112, 134),
-            current: Color::Rgb(249, 226, 175),
-            table_bg: Color::Rgb(49, 50, 68),
-            table_border: Color::Rgb(108, 112, 134),
-            menu_highlight: Color::Rgb(137, 180, 250),
+            background: Color::Rgb(26, 27, 38),      // Tokyonight bg
+            text: Color::Rgb(192, 202, 245),         // Tokyonight fg
+            accent: Color::Rgb(122, 162, 247),       // Blue
+            correct: Color::Rgb(158, 206, 106),      // Green
+            incorrect: Color::Rgb(247, 118, 142),    // Red
+            pending: Color::Rgb(86, 95, 137),        // Grey
+            current: Color::Rgb(122, 162, 247),      // Blue for cursor
+            table_bg: Color::Rgb(31, 35, 53),
+            table_border: Color::Rgb(65, 72, 104),
+            menu_highlight: Color::Rgb(122, 162, 247),
         }
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -20,7 +20,7 @@ impl Default for Theme {
             background: Color::Rgb(26, 27, 38),      // Tokyonight bg
             text: Color::Rgb(192, 202, 245),         // Tokyonight fg
             accent: Color::Rgb(122, 162, 247),       // Blue
-            correct: Color::Rgb(158, 206, 106),      // Green
+            correct: Color::Rgb(122, 162, 247),      // Blue for correct words
             incorrect: Color::Rgb(247, 118, 142),    // Red
             pending: Color::Rgb(86, 95, 137),        // Grey
             current: Color::Rgb(122, 162, 247),      // Blue for cursor

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,8 @@
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, BorderType, List, ListItem, ListState, Paragraph, Wrap, Table, Row, Cell, Clear};
+use ratatui::widgets::{Block, Borders, BorderType, List, ListItem, ListState, Paragraph, Wrap, Table, Row, Cell, Clear, Tabs, Padding};
 
 use crate::{App, AppMode, Theme};
+use random_word::Lang;
 
 pub fn draw(f: &mut Frame, app: &App, theme: &Theme) {
     match app.mode {
@@ -42,6 +43,45 @@ fn build_text(app: &App, theme: &Theme) -> Text<'static> {
 }
 
 fn draw_menu(f: &mut Frame, app: &App, theme: &Theme) {
+    let area = centered_rect(40, 50, f.size());
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([Constraint::Length(3), Constraint::Min(3)])
+        .split(area);
+
+    let titles: Vec<Line> = app
+        .languages
+        .iter()
+        .map(|l| match l {
+            Lang::En => Line::from("English"),
+            Lang::Es => Line::from("Spanish"),
+            Lang::De => Line::from("German"),
+        })
+        .collect();
+    let tabs = Tabs::new(titles)
+        .select(app.lang_selected)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Double)
+                .style(Style::default().bg(theme.background).fg(theme.text))
+                .title(Span::styled(
+                    "Language",
+                    Style::default()
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::BOLD),
+                )),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(theme.background)
+                .bg(theme.menu_highlight)
+                .add_modifier(Modifier::BOLD),
+        );
+    f.render_widget(Clear, area);
+    f.render_widget(tabs, chunks[0]);
+
     let items: Vec<ListItem> = app
         .durations
         .iter()
@@ -69,9 +109,7 @@ fn draw_menu(f: &mut Frame, app: &App, theme: &Theme) {
         .highlight_symbol(" > ");
     let mut state = ListState::default();
     state.select(Some(app.selected));
-    let area = centered_rect(30, 40, f.size());
-    f.render_widget(Clear, area);
-    f.render_stateful_widget(list, area, &mut state);
+    f.render_stateful_widget(list, chunks[1], &mut state);
 }
 
 fn draw_typing(f: &mut Frame, app: &App, theme: &Theme) {
@@ -107,6 +145,7 @@ fn draw_typing(f: &mut Frame, app: &App, theme: &Theme) {
                 .add_modifier(Modifier::BOLD),
         ));
     let paragraph = Paragraph::new(text)
+        .style(Style::default().add_modifier(Modifier::BOLD))
         .block(block)
         .wrap(Wrap { trim: false });
     f.render_widget(paragraph, chunks[1]);
@@ -157,9 +196,11 @@ fn draw_summary(f: &mut Frame, app: &App, theme: &Theme) {
                     Style::default()
                         .fg(theme.accent)
                         .add_modifier(Modifier::BOLD),
-                )),
+                ))
+                .padding(Padding::new(2, 2, 1, 1)),
         )
-        .column_spacing(2);
+        .column_spacing(4)
+        .style(Style::default().add_modifier(Modifier::BOLD));
     f.render_widget(Clear, area);
     f.render_widget(table, chunks[0]);
 

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -1,15 +1,5 @@
-use rand::seq::SliceRandom;
+use random_word::{self, Lang};
 
-static DEFAULT_WORDS: &[&str] = &[
-    "apple", "banana", "orange", "grape", "mango",
-    "computer", "keyboard", "monitor", "mouse", "screen",
-    "rust", "cargo", "compile", "code", "debug",
-    "terminal", "prompt", "library", "crate", "module",
-];
-
-pub fn random_words(count: usize) -> Vec<String> {
-    let mut rng = rand::thread_rng();
-    let mut words = DEFAULT_WORDS.to_vec();
-    words.shuffle(&mut rng);
-    words.iter().take(count).map(|w| w.to_string()).collect()
+pub fn random_words(count: usize, lang: Lang) -> Vec<String> {
+    (0..count).map(|_| random_word::get(lang).to_string()).collect()
 }


### PR DESCRIPTION
## Summary
- add `random_word` crate with English, Spanish and German dictionaries
- switch colors to a Tokyonight-based theme
- allow language selection in menu with tabs
- generate words in the selected language
- enlarge text and add padding to summary table

## Testing
- `cargo check --quiet`
- `cargo build --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6841eeb27b9483339c56c4da467c5626